### PR TITLE
Add POS priority supporting

### DIFF
--- a/analyzeMorphologyAccuracy.py
+++ b/analyzeMorphologyAccuracy.py
@@ -4,6 +4,7 @@ from libs.accuracy import XPOSRecognitionAnalyzer
 from importlib import import_module
 from libs.ui import percentage
 from libs.logs import Logger
+import json
 
 
 argv = Params()
@@ -27,6 +28,11 @@ Name             Default     Description
                              path.module.class.function
                              module.class.property.function
                              ...
+                             Default is
+                             libs.morphology.MorphologyRecognizer.selectFirst
+--priority ...   None        Priority list in JSON format is it documented in
+                             MorhologyRecognizer module. Don't forget to
+                             escape quotes!
 --limit ...      0           Limit of tokens to be processed. Set to '0' to set
                              it to infinite.
 --offset ...     0           Skip first N tokens from UD file you've specified.
@@ -63,6 +69,10 @@ while len(applierAddr) > 0:
 
 reader = getattr(import_module("libs.gc"), argv.get("--reader"))
 
+priorityList = None
+if argv.has("--priority"):
+    priorityList = json.loads(argv.get("--priority", default=None))
+
 limit = int(argv.get("--limit", default="0"))
 offset = int(argv.get("--offset", default="0"))
 
@@ -83,7 +93,8 @@ analyzer = XPOSRecognitionAnalyzer(
             argv.get("--collection")
         )
     ),
-    applierFunction=applier
+    applierFunction=applier,
+    priorityList=priorityList
 )
 
 logger.write(f"Connected to {analyzer.recognizer.collection.name}\n")

--- a/libs/accuracy.py
+++ b/libs/accuracy.py
@@ -30,7 +30,9 @@ class XPOSRecognitionAnalyzer:
     IMPROVE_XPOS = 0
     IMPROVE_UPOS = 0
 
-    def __init__(self, reader, limit, offset, recognizer, applierFunction):
+    def __init__(
+        self, reader, limit, offset, recognizer, applierFunction, priorityList
+    ):
         """Prepare an analyser.
 
         Args:
@@ -42,6 +44,8 @@ class XPOSRecognitionAnalyzer:
             recognizer (MorphologyRecognizer): A class specified in
                 morphology.py. It should contain recognize() method.
             applierFunction (function): Applier function for your recognizer.
+            priorityList (list): List of priorities as it documented in
+                MorhologyRecognizer module.
 
         """
         self.reader = reader
@@ -49,6 +53,7 @@ class XPOSRecognitionAnalyzer:
         self.offset = offset
         self.recognizer = recognizer
         self.applier = applierFunction
+        self.priorityList = priorityList
 
     def init(self):
         """Init a generator function. next() does the next check and returns
@@ -92,7 +97,9 @@ class XPOSRecognitionAnalyzer:
                 )
 
                 result = self.recognizer.recognize(token)
-                applierResult = self.recognizer.recognize(token, self.applier)
+                applierResult = self.recognizer.recognize(
+                    token, self.applier, self.priorityList
+                )
 
                 self.CHECKED += 1
 

--- a/libs/arrproc.py
+++ b/libs/arrproc.py
@@ -57,5 +57,46 @@ def reorder(li: list, a: int, b: int):
         <<< [b, a, c]
 
     """
+
     li[a], li[b] = li[b], li[a]
     return li
+
+
+def containesSupsetDict(li: list, search: dict):
+    """Check whether list contains dict that is superset for specified dict.
+
+    Args:
+        li (list): List to search in.
+        search (dict): Dictionary to compare.
+
+    Returns:
+        True: If one was found.
+        False: Otherwise.
+
+    Example:
+        Suppose:
+        search = {
+            a: 0,
+            b: 1,
+            c: 2
+        }
+        True will be returned if `li` contains this dictionary:
+        {
+            a: 0,
+            b: 1,
+            c: 2,
+            d: 3
+        }
+        or this:
+        {
+            a: 0,
+            b: 1
+        }
+
+    """
+
+    for item in li:
+        if search.items() <= item.items():
+            return True
+
+    return False


### PR DESCRIPTION
Suppose, we have this data:
```json
priorityList = {
    "Q": {
        "xpos": "Css",
        "upos": "CCONJ"
    }
}
```
That means the every occuring of `Q` XPOS will be replaced with `CCONJ Css` POS, but only when both of them are presented in DB response. Any other parameters specified in `dict` will be added to the token's rule too.  
This may be useful when two equal words appears to be different POS, but one of them more frequent.