### PR TITLE
Detach Prioritizer class from MorphologyRecognizer

### DIFF
--- a/anmorphacc.py
+++ b/anmorphacc.py
@@ -100,10 +100,10 @@ analyzer = XPOSRecognitionAnalyzer(
             )
         ).cli.get_collection(
             argv.get("--collection")
-        )
+        ),
+        priorityList=priorityList
     ),
-    applierFunction=applier,
-    priorityList=priorityList
+    applierFunction=applier
 )
 
 logger.write(f"Connected to {analyzer.recognizer.collection.name}\n")

--- a/libs/accuracy.py
+++ b/libs/accuracy.py
@@ -55,7 +55,6 @@ class XPOSRecognitionAnalyzer:
         self.offset = offset if offset else 0
         self.recognizer = recognizer
         self.applier = applierFunction
-        self.priorityList = priorityList
 
     def init(self):
         """Init a generator function next() does the next check and returns
@@ -100,7 +99,7 @@ class XPOSRecognitionAnalyzer:
 
                 result = self.recognizer.recognize(token)
                 applierResult = self.recognizer.recognize(
-                    token, self.applier, self.priorityList
+                    token, self.applier
                 )
 
                 self.CHECKED += 1

--- a/libs/arrproc.py
+++ b/libs/arrproc.py
@@ -62,41 +62,20 @@ def reorder(li: list, a: int, b: int):
     return li
 
 
-def containesSupsetDict(li: list, search: dict):
-    """Check whether list contains dict that is superset for specified dict.
+def isSupsetTo(d: dict, what: dict):
+    """Check whether one `d` dict is supset or equal to `what` dict. This means
+    that all the items from `what` is equal to `d`.
 
     Args:
-        li (list): List to search in.
-        search (dict): Dictionary to compare.
+        d, what (dict): Dicts to compare.
 
     Returns:
-        True: If one was found.
-        False: Otherwise.
-
-    Example:
-        Suppose:
-        search = {
-            a: 0,
-            b: 1,
-            c: 2
-        }
-        True will be returned if `li` contains this dictionary:
-        {
-            a: 0,
-            b: 1,
-            c: 2,
-            d: 3
-        }
-        or this:
-        {
-            a: 0,
-            b: 1
-        }
+        bool: True if d > what, False otherwise.
 
     """
 
-    for item in li:
-        if search.items() <= item.items():
-            return True
+    for key, value in what.items():
+        if d[key] != value:
+            return False
 
-    return False
+    return True

--- a/libs/ctxmorph.py
+++ b/libs/ctxmorph.py
@@ -48,11 +48,10 @@ class ContextualProcessor:
 
         self.collection = collection
         self.recognizer = MorphologyRecognizer(
-            collection, tagparser=tagparser
+            collection, tagparser=tagparser, priorityList=priority
         )
         self.tagparser = tagparser
         self.applier = applier
-        self.priority = priority
         self.ctx19 = Contextual19Parser()
 
         if not rulescoll:
@@ -90,8 +89,7 @@ class ContextualProcessor:
         for token in tokens:
             recognized = self.recognizer.recognize(
                 token=token,
-                applierFunc=self.applier,
-                priorityList=self.priority
+                applierFunc=self.applier
             )
             # Return empty dict if token was not recognized
             if not recognized:

--- a/libs/tmr/human.py
+++ b/libs/tmr/human.py
@@ -56,12 +56,13 @@ class HumanTrainer(MorphologyRecognizeTrainer):
                 applier, applierAddr.pop(0)
             )
 
-        recognizer = MorphologyRecognizer(
-            collection=self.rulescollection
-        )
-
         priorityList = json.load(
             open(self.settings["priorityList"])
+        )
+
+        recognizer = MorphologyRecognizer(
+            collection=self.rulescollection,
+            priorityList=priorityList
         )
 
         counter = 0
@@ -103,13 +104,9 @@ class HumanTrainer(MorphologyRecognizeTrainer):
 
                             self.logger.output(f"Current token is: {token}")
 
-                            recogn = recognizer.recognize(
-                                token, applier
-                            )
-
                             result = recognizer.recognize(token)
                             appRes = recognizer.recognize(
-                                token, applier, priorityList
+                                token, applier
                             )
 
                             if appRes:
@@ -121,8 +118,8 @@ class HumanTrainer(MorphologyRecognizeTrainer):
 
                                 if xpos == appRes["xpos"]:
                                     ruleType = (
-                                        recogn['type']
-                                        if recogn['type'] else "<unknown>"
+                                        appRes['type']
+                                        if appRes['type'] else "<unknown>"
                                     )
                                     self.logger.output(
                                         "Recognized correctly. "

--- a/xpostrain.py
+++ b/xpostrain.py
@@ -92,7 +92,7 @@ try:
         # This will import class with specified name from gc module and init it
         # with given parameters.
         gcreader=getattr(import_module("libs.ud." + reader[0]), reader[1])(
-            fp=open(argv.get("--path")),
+            fp=open(argv.get("--path"), encoding="utf-8"),
             ignoreComments=True,
             strict=False if argv.has("-unstrict") else True
         ),
@@ -106,7 +106,7 @@ except (StopIteration, EOFError):
     pass
 finally:
     length = len(trainer.poses)
-    trainer.log(f"Collected {length} XPOSes.\n")
+    logger.write(f"Collected {length} XPOSes.\n")
     logger.output(f"\nCollected {length} XPOSes.\n")
 
 # This will get iteration function and execute it


### PR DESCRIPTION
This class adds `Prioritizer` module and changes structure of prioritizing list from this:
```
{
	"tag-to-replace": {"new-property": "new-value", ...},
	...
}
```
to this:
```
{
	{
		"__what": {"prop-to-replace": "val-to-replace", ...},
		"__replace": {"new-prop": "new-val", ...}
	},
	...
}
```
This will allow to create more complicated rules and avoid rewriting tag definition like here:
`{"Q": {"xpos": "CCONJ"}, "Q": {"xpos": "ADP"}}`